### PR TITLE
Fix ship detail user list loading

### DIFF
--- a/ops/views.py
+++ b/ops/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib import messages
 from .models import Ship, RoleSlot
@@ -42,8 +43,19 @@ def ship_detail(request, pk):
             messages.success(request, "Rôle ajouté au vaisseau.")
             return redirect("ship_detail", pk=ship.pk)
 
-    return render(request, "ops/ship_detail.html",
-                  {"ship": ship, "slots_by_role": slots_by_role, "role_form": role_form, "can_edit": can_edit})
+    users = get_user_model().objects.order_by("username") if can_edit else []
+
+    return render(
+        request,
+        "ops/ship_detail.html",
+        {
+            "ship": ship,
+            "slots_by_role": slots_by_role,
+            "role_form": role_form,
+            "can_edit": can_edit,
+            "all_users": users,
+        },
+    )
 
 @login_required
 @user_passes_test(is_planner)

--- a/templates/ops/ship_detail.html
+++ b/templates/ops/ship_detail.html
@@ -37,7 +37,7 @@
         <div class="text-xs text-white/60 mb-2">Slot #{{ s.index }}</div>
         <select name="user" class="w-full bg-black/40 border border-white/15 rounded px-2 py-1 mb-2">
           <option value="">— free —</option>
-          {% for u in request.user.__class__.objects.all %}
+          {% for u in all_users %}
           <option value="{{ u.id }}" {% if s.user_id == u.id %}selected{% endif %}>{{ u.username }}</option>
           {% endfor %}
         </select>


### PR DESCRIPTION
## Summary
- load available users for role assignments in the ship detail view using Django's user model
- pass the user list to the template only when the viewer can edit, avoiding lazy user attribute errors
- update the template to iterate over the provided user list when rendering the assignment dropdowns

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68dfda93ffd883239b52799b9108da62