### PR TITLE
Harden layout chrome and tag resolution

### DIFF
--- a/ops/admin.py
+++ b/ops/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
+
 from .models import Ship, ShipRoleTemplate, RoleSlot
+from .utils import resolve_username_lookup
 
 class ShipRoleTemplateInline(admin.TabularInline):
     model = ShipRoleTemplate
@@ -16,4 +18,7 @@ class ShipAdmin(admin.ModelAdmin):
 class RoleSlotAdmin(admin.ModelAdmin):
     list_display = ("ship", "role_name", "index", "user", "status")
     list_filter = ("ship", "role_name", "status")
-    search_fields = ("ship__name", "role_name", "user__username")
+
+    def get_search_fields(self, request):
+        _, identifier = resolve_username_lookup()
+        return ("ship__name", "role_name", f"user__{identifier}")

--- a/ops/forms.py
+++ b/ops/forms.py
@@ -1,6 +1,8 @@
 from django import forms
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+
 from .models import ShipRoleTemplate, RoleSlot
+from .utils import get_ordered_user_queryset
 
 class ShipRoleTemplateForm(forms.ModelForm):
     class Meta:
@@ -8,7 +10,16 @@ class ShipRoleTemplateForm(forms.ModelForm):
         fields = ("role_name", "slots")
 
 class RoleSlotForm(forms.ModelForm):
-    user = forms.ModelChoiceField(label="Utilisateur", queryset=User.objects.order_by("username"), required=False)
+    user = forms.ModelChoiceField(
+        label="Utilisateur",
+        queryset=get_user_model()._default_manager.none(),
+        required=False,
+    )
+
     class Meta:
         model = RoleSlot
         fields = ("user", "status")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["user"].queryset = get_ordered_user_queryset()

--- a/ops/models.py
+++ b/ops/models.py
@@ -1,5 +1,5 @@
+from django.conf import settings
 from django.db import models
-from django.contrib.auth.models import User
 
 class Ship(models.Model):
     name = models.CharField("Nom du vaisseau", max_length=80, unique=True)
@@ -44,7 +44,7 @@ class RoleSlot(models.Model):
     role_name = models.CharField("Rôle", max_length=40)
     index = models.PositiveSmallIntegerField("N° de place", default=1)
     user = models.ForeignKey(
-        User,
+        settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -67,5 +67,5 @@ class RoleSlot(models.Model):
         verbose_name_plural = "Places de rôle"
 
     def __str__(self):
-        who = self.user.username if self.user else "libre"
+        who = self.user.get_username() if self.user else "libre"
         return f"{self.ship} · {self.role_name} #{self.index} → {who}"

--- a/ops/templatetags/ops_extras.py
+++ b/ops/templatetags/ops_extras.py
@@ -1,0 +1,45 @@
+import logging
+
+from django import template
+from django.urls import Resolver404, resolve
+
+from ..utils import get_ordered_user_queryset
+
+register = template.Library()
+logger = logging.getLogger(__name__)
+
+
+@register.simple_tag
+def ordered_users():
+    """Expose the ordered user queryset to templates."""
+
+    return get_ordered_user_queryset()
+
+
+@register.simple_tag(takes_context=True)
+def current_url_name(context):
+    """Return the resolved URL name for the current request.
+
+    Some runtime contexts (notably the CSRF failure view) render templates
+    without attaching ``resolver_match`` to the request.  Accessing
+    ``request.resolver_match`` in templates would then raise an ``AttributeError``
+    and blow up the response.  We resolve the path manually in those rare cases
+    and default to an empty string when resolution fails so callers can perform
+    defensive comparisons.
+    """
+
+    request = context.get("request")
+    if request is None:
+        return ""
+
+    match = getattr(request, "resolver_match", None)
+    if match is None:
+        try:
+            match = resolve(request.path_info)
+        except Resolver404:
+            return ""
+        except Exception:  # pragma: no cover - defensive safety net
+            logger.exception("Failed to resolve URL for path %s", getattr(request, "path_info", "<unknown>"))
+            return ""
+
+    return match.url_name or ""

--- a/ops/tests.py
+++ b/ops/tests.py
@@ -1,3 +1,78 @@
-from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.template import Context, Template
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Ship
+from .utils import get_ordered_user_queryset, resolve_username_lookup
+
+
+class UserOrderingUtilsTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.User = get_user_model()
+        cls.original_username_field = getattr(cls.User, "USERNAME_FIELD", "username")
+        # Create users with intentionally unordered identifiers.
+        cls.u1 = cls.User.objects.create_user(username="zoe", password="pass", email="zoe@example.com")
+        cls.u2 = cls.User.objects.create_user(username="anna", password="pass", email="anna@example.com")
+        cls.u3 = cls.User.objects.create_user(username="mike", password="pass", email="mike@example.com")
+
+    def tearDown(self):
+        # Restore the USERNAME_FIELD if tests changed it.
+        self.User.USERNAME_FIELD = self.original_username_field
+
+    def test_resolve_username_lookup_returns_configured_field(self):
+        _, field_name = resolve_username_lookup()
+        self.assertEqual(field_name, self.original_username_field)
+
+    def test_resolve_username_lookup_falls_back_to_pk(self):
+        self.User.USERNAME_FIELD = "nonexistent_field"
+        _, field_name = resolve_username_lookup()
+        self.assertEqual(field_name, "pk")
+
+    def test_get_ordered_queryset_falls_back_to_pk(self):
+        self.User.USERNAME_FIELD = "nonexistent_field"
+        ordered_ids = list(get_ordered_user_queryset().values_list("pk", flat=True))
+        expected_ids = list(self.User._default_manager.order_by("pk").values_list("pk", flat=True))
+        self.assertEqual(ordered_ids, expected_ids)
+
+
+class CurrentUrlNameTagTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def render_tag(self, path):
+        request = self.factory.get(path)
+        template = Template("{% load ops_extras %}{% current_url_name as name %}{{ name }}")
+        return template.render(Context({"request": request}))
+
+    def test_returns_resolved_url_name(self):
+        rendered = self.render_tag(reverse("ships_list"))
+        self.assertEqual(rendered, "ships_list")
+
+    def test_returns_empty_string_when_resolution_fails(self):
+        rendered = self.render_tag("/does-not-exist/")
+        self.assertEqual(rendered, "")
+
+
+class LayoutChromeTests(TestCase):
+    def setUp(self):
+        get_user_model().objects.create_user("nav", "nav@example.com", "pass")
+
+    def test_login_page_hides_navigation_for_anonymous_users(self):
+        response = self.client.get(reverse("login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Déconnexion")
+
+    def test_login_page_hides_navigation_for_authenticated_users(self):
+        self.client.login(username="nav", password="pass")
+        response = self.client.get(reverse("login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Déconnexion")
+
+    def test_authenticated_users_see_navigation_on_application_pages(self):
+        self.client.login(username="nav", password="pass")
+        Ship.objects.create(name="Cetus", category="MR", min_crew=1, max_crew=4)
+        response = self.client.get(reverse("ships_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Déconnexion")

--- a/ops/utils.py
+++ b/ops/utils.py
@@ -1,0 +1,33 @@
+"""Utility helpers for working with the configured user model."""
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import FieldDoesNotExist, FieldError
+
+
+def resolve_username_lookup():
+    """Return the active user model and a safe field name for ordering.
+
+    The configured ``USERNAME_FIELD`` may not map to a real database field
+    (for instance when authentication is handled via an adapter property).
+    In that case we gracefully fall back to the primary key so lookups remain
+    valid instead of raising ``FieldError`` at query time.
+    """
+
+    user_model = get_user_model()
+    order_field = getattr(user_model, "USERNAME_FIELD", "username")
+    try:
+        user_model._meta.get_field(order_field)
+    except FieldDoesNotExist:
+        order_field = "pk"
+    return user_model, order_field
+
+
+def get_ordered_user_queryset():
+    """Return a queryset of users ordered by a safe identifier field."""
+
+    user_model, order_field = resolve_username_lookup()
+    manager = user_model._default_manager
+    try:
+        return manager.order_by(order_field)
+    except FieldError:
+        return manager.order_by("pk")

--- a/ops/views.py
+++ b/ops/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.contrib import messages
 from .models import Ship, RoleSlot
 from .forms import RoleSlotForm, ShipRoleTemplateForm
+from .utils import get_ordered_user_queryset
 
 def is_planner(user):
     return user.is_superuser or user.groups.filter(name__in=["Planner", "Administrateur", "Planificateur"]).exists()
@@ -42,8 +43,20 @@ def ship_detail(request, pk):
             messages.success(request, "Rôle ajouté au vaisseau.")
             return redirect("ship_detail", pk=ship.pk)
 
-    return render(request, "ops/ship_detail.html",
-                  {"ship": ship, "slots_by_role": slots_by_role, "role_form": role_form, "can_edit": can_edit})
+    users_qs = get_ordered_user_queryset()
+    users = users_qs if can_edit else users_qs.none()
+
+    return render(
+        request,
+        "ops/ship_detail.html",
+        {
+            "ship": ship,
+            "slots_by_role": slots_by_role,
+            "role_form": role_form,
+            "can_edit": can_edit,
+            "all_users": users,
+        },
+    )
 
 @login_required
 @user_passes_test(is_planner)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="fr" class="h-full">
+{% load ops_extras %}
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -15,7 +16,8 @@
 <body class="h-full bg-black text-white">
   <div class="noise"></div>
 
-  {% if user.is_authenticated and request.resolver_match.url_name != 'login' %}
+  {% current_url_name as url_name %}
+  {% if user.is_authenticated and url_name and url_name != 'login' %}
   <!-- Header (visible UNIQUEMENT hors page de login) -->
   <header class="border-b border-white/10 bg-black/60 backdrop-blur sticky top-0 z-40">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
@@ -35,7 +37,7 @@
     {% block body %}{% endblock %}
   </main>
 
-  {% if user.is_authenticated and request.resolver_match.url_name != 'login' %}
+  {% if user.is_authenticated and url_name and url_name != 'login' %}
   <footer class="border-t border-white/10 text-xs text-white/50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 h-12 flex items-center justify-between">
       <span>© C.K.F.R</span>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,6 +1,6 @@
 <!doctype html><html><head><meta charset="utf-8"><title>CKFR Dashboard</title></head>
 <body>
   <h1>Dashboard</h1>
-  <p>Hello, {{ request.user.username }}!</p>
+  <p>Hello, {{ request.user.get_username }}!</p>
   <p><a href="/admin/">Admin</a> · <a href="/logout/">Logout</a></p>
 </body></html>

--- a/templates/ops/operation_detail.html
+++ b/templates/ops/operation_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load ops_extras %}
 {% block title %}{{ op.title }} · C.K.F.R{% endblock %}
 {% block body %}
 <div class="max-w-5xl mx-auto p-4 sm:p-6 space-y-6">
@@ -22,10 +23,11 @@
           <form method="post" action="{% url 'assignment_update' a.pk %}" class="rounded-lg bg-white/10 p-3">
             {% csrf_token %}
             <div class="text-sm text-slate-300 mb-2">{{ a.role_name }}</div>
+            {% ordered_users as assignable_users %}
             <select name="user" class="w-full bg-white/5 border border-white/10 rounded px-2 py-1 mb-2">
               <option value="">— libre —</option>
-              {% for u in request.user.__class__.objects.all %}
-                <option value="{{ u.id }}" {% if a.user_id == u.id %}selected{% endif %}>{{ u.username }}</option>
+              {% for u in assignable_users %}
+                <option value="{{ u.pk }}" {% if a.user_id == u.pk %}selected{% endif %}>{{ u.get_username }}</option>
               {% endfor %}
             </select>
             <select name="status" class="w-full bg-white/5 border border-white/10 rounded px-2 py-1 mb-2">

--- a/templates/ops/ship_detail.html
+++ b/templates/ops/ship_detail.html
@@ -37,8 +37,8 @@
         <div class="text-xs text-white/60 mb-2">Slot #{{ s.index }}</div>
         <select name="user" class="w-full bg-black/40 border border-white/15 rounded px-2 py-1 mb-2">
           <option value="">— free —</option>
-          {% for u in request.user.__class__.objects.all %}
-          <option value="{{ u.id }}" {% if s.user_id == u.id %}selected{% endif %}>{{ u.username }}</option>
+          {% for u in all_users %}
+          <option value="{{ u.pk }}" {% if s.user_id == u.pk %}selected{% endif %}>{{ u.get_username }}</option>
           {% endfor %}
         </select>
         <select name="status" class="w-full bg-black/40 border border-white/15 rounded px-2 py-1 mb-3">

--- a/templates/ops/ships_list.html
+++ b/templates/ops/ships_list.html
@@ -5,7 +5,7 @@
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
     <h1 class="text-2xl sm:text-3xl font-semibold">Ships</h1>
     <div class="flex flex-wrap gap-2">
-      <a href="?" class="px-3 py-1.5 rounded-full border border-white/15 text-sm {{ not current_cat|yesno:',bg-white/10' }}">All</a>
+      <a href="?" class="px-3 py-1.5 rounded-full border border-white/15 text-sm {% if not current_cat %}bg-white/10{% endif %}">All</a>
       {% for c,val in categories %}
       <a href="?cat={{ c }}" class="px-3 py-1.5 rounded-full border border-white/15 text-sm {% if current_cat == c %}bg-white/10{% endif %}">
         {{ val }}


### PR DESCRIPTION
## Summary
- guard the layout header/footer so they stay hidden on login when the resolver name is blank
- add defensive logging around URL resolution to avoid unexpected template-tag crashes
- cover the navigation visibility logic with regression tests for anonymous and authenticated users

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68dfda93ffd883239b52799b9108da62